### PR TITLE
Fix links: /gems -> /components

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@ $ teletype add search
       </ul>
 
       <p class="center">
-        <a href="{{ relative_url }}/gems" class="button">View all components</a>
+        <a href="{{ relative_url }}/components" class="button">View all components</a>
       </p>
     </div>
   </div>
@@ -107,7 +107,7 @@ $ teletype add search
     <ul class="setup-strip">
       <li class="setup-desc">
         <h2 class="setup-header">Installing a Component</h2>
-        <p>TTY components are installed and managed via <a href="http://rubygems.org">rubygems</a>, the <a href="http://www.ruby-lang.org/en/">ruby</a> package manager. Choose the <a href="{{ relative_url }}/gems">tty component</a> that matches your needs and install it using its name.</p>
+        <p>TTY components are installed and managed via <a href="http://rubygems.org">rubygems</a>, the <a href="http://www.ruby-lang.org/en/">ruby</a> package manager. Choose the <a href="{{ relative_url }}/components">tty component</a> that matches your needs and install it using its name.</p>
       </li>
       <li class="setup-terminal">
         <div class="terminal">


### PR DESCRIPTION
Two links from the homepage do not work. They link to non-existing `/gems` page, I guess you meant `/components` :wink: 

And thanks for this great set of tools by the way!